### PR TITLE
Unit Tests

### DIFF
--- a/lib/integrations/google-analytics.js
+++ b/lib/integrations/google-analytics.js
@@ -14,13 +14,13 @@ module.exports = {
 
     return { trackingId: trackingId };
 
-    function getUniversal () {
+    function getUniversal() {
       var tracker = ga.getAll()[0];
       var trackingId = tracker.get('trackingId');
       return trackingId;
     }
 
-    function getClassic () {
+    function getClassic() {
       var pageTracker = _gat._getTrackerByName();
       var accountId = pageTracker._getAccount();
       return accountId;

--- a/test/integrations.js
+++ b/test/integrations.js
@@ -1,0 +1,77 @@
+var integrations = require('../lib/integrations');
+var assert = require('assert');
+var vm = require('vm');
+
+describe('integrations', function () {
+  describe('Google Analytics', function () {
+    var integration = integrations['Google Analytics'];
+
+    it('should match all the correct URLs via pattern', function () {
+      var urls = [
+        'google-analytics.com/analytics.js',
+        'google-analytics.com/urchin.js',
+        'google-analytics.com/ga_exp.js',
+        'google-analytics.com/ga.js',
+        'google-analytics.com/u/ga_debug.js',
+        'google-analytics.com/u/ga_beta.js',
+        'google-analytics.com/u/ga.js',
+        'google-analytics.com/cx/api.js',
+        'google-analytics.com/collect'
+      ];
+
+      urls.forEach(function (url) {
+        assert(url.match(integration.pattern), url + ' should have been matched');
+      });
+    });
+
+    it('should return the right settings object for the universal script', function () {
+      var ga = {
+        getAll: function () {
+          return [
+            {
+              get: function () {
+                return 'UA-XXXXX-XX';
+              }
+            }
+          ];
+        }
+      };
+
+      var ctx = {
+        window: {
+          ga: ga
+        },
+        ga: ga
+      };
+
+      var fn = 'settings = (' + integration.settings.toString() + ')()';
+      vm.runInNewContext(fn, ctx)
+
+      assert.deepEqual(ctx.settings, { trackingId: 'UA-XXXXX-XX' });
+    });
+
+    it('should return the right settings object for the classic script', function () {
+      var gat = {
+        _getTrackerByName: function () {
+          return {
+            _getAccount: function () {
+              return 'UA-XXXXX-XX';
+            }
+          };
+        }
+      };
+
+      var ctx = {
+        window: {
+          _gat: gat
+        },
+        _gat: gat
+      };
+
+      var fn = 'settings = (' + integration.settings.toString() + ')()';
+      vm.runInNewContext(fn, ctx)
+
+      assert.deepEqual(ctx.settings, { trackingId: 'UA-XXXXX-XX' });
+    });
+  });
+});


### PR DESCRIPTION
This adds very low-level unit tests for the GA integration. The idea will be that we add all the nitty gritty tests for things like matching URLs and generating settings objects.

Once we have 100% coverage of the individual units, then we can focus on more generic interfaces for the integration tests. (ie: we're testing things like "does the integration get detected on page load?" instead of "does the script URL match?")

/cc @stevenmiller888 
